### PR TITLE
Remove yt3.ggpht.com

### DIFF
--- a/Blocklist.txt
+++ b/Blocklist.txt
@@ -221,7 +221,6 @@ www.coin-hive.com
 mqtt.c10r.facebook.com
 telegraph-ash.instagram.com
 white.ish.instagram.com
-yt3.ggpht.com
 adserver.snapads.com
 adserver.shadow.snapads.com
 beacons.gvt2.com

--- a/PiHole_HOSTS_Spyware.txt
+++ b/PiHole_HOSTS_Spyware.txt
@@ -1,5 +1,3 @@
-*.80gw6ry3i3x3qbrkwhxhw.*
-*.first-antivirmd.*
 007guard.com
 008i.com
 008k.com
@@ -5839,7 +5837,6 @@ hausaufgaben.de
 hausaufgaben-download.de
 hausaufgaben-heute.com
 hausaufgaben-referate.de
-hausaufgaben–referate.de
 hausaufgaben-referate.net
 hausaufgaben-schnell-gemacht.de
 hausaufgaben-server.com
@@ -13861,7 +13858,6 @@ wwfcfpmfwpompwow.info
 wwlax.com
 wwlax.com.wrsnav
 wwvyoutube.com
-www.install.*
 www1.beruijindegunhadesun.com
 www1.first-antivirmd.25u.com
 www1.saverpnsentinel.uni.me


### PR DESCRIPTION
Please remove yt3.ggpht.com
This breaks Youtube comment avatars

Additionally, you should enable people to create "issues" in this repo, so we can report problems with your list, without having to create a pull request.