### PR TITLE
prod-tp.sumo.mozit.cloud is a CNAME for support.mozilla.org

### DIFF
--- a/PiHole/Blocklist_HOSTS.txt
+++ b/PiHole/Blocklist_HOSTS.txt
@@ -553,7 +553,6 @@ www.innsbruck-kuenstler.info
 eu.cssrvsync.com
 tracker5.naturalbid.com
 tracker11.naturalbid.com
-prod-tp.sumo.mozit.cloud
 pushimg.com
 us-nj-e19.rtbtradein.com
 us-nj-e6.rtbtradein.com


### PR DESCRIPTION
@XionKzn